### PR TITLE
Loosen callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/eslint-config",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Shared eslint config for hmcts projects",
   "main": "index.js",
   "repository": "https://github.com/hmcts/eslint-config",

--- a/test.js
+++ b/test.js
@@ -5,5 +5,6 @@ module.exports = {
   rules: Object.assign({}, defaults.rules, {
     'arrow-body-style': 'off',
     'newline-per-chained-call': 'off'
+    'max-nested-callbacks': ['error', 5],
   })
 }


### PR DESCRIPTION
In a test suite `describe` and `it` blocks will take up at least 2 of
your max 3 nested callbacks.

e.g.
```
describe('@hmcts/look-and-feel', () => {
  describe('.configure()', () => {
    it('throws if baseUrl is not defined', () => {
      const app = express();
      expect(() => lookAndFeel.configure(app)).to.throw(Error, /baseUrl/);
    });
  });
});
```

This test complains of too many nested callbacks. In reality the mocha `describe` and `it` blocks are not adding actual complexity to the code.

For this reason we allow 2 extra callbacks in a test suite, as otherwise you
wouldn't be able to properly test callback based interfaces.