### PR TITLE
Allow magic numbers and undefined in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/eslint-config",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Shared eslint config for hmcts projects",
   "main": "index.js",
   "repository": "https://github.com/hmcts/eslint-config",

--- a/test.js
+++ b/test.js
@@ -5,6 +5,8 @@ module.exports = {
   rules: Object.assign({}, defaults.rules, {
     'arrow-body-style': 'off',
     'newline-per-chained-call': 'off',
-    'max-nested-callbacks': ['error', 5]
+    'max-nested-callbacks': ['error', 5],
+    'no-undefined': 'off',
+    'no-magic-numbers': 'off'
   })
 }


### PR DESCRIPTION
In a test suite it's desired to test against edge cases and bad usage.
In these tests you would use a variety of numbers and `undefined` to see
what your unit does under those values.

This relaxes the linting for tests to allow test suites to perform these
checks without twisting the code.