### PR TITLE
Complexity and statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ module.exports = {
     'accessor-pairs': 'error',
     'array-callback-return': 'error',
     'block-scoped-var': 'error',
-    complexity: ['error', 3],
+    complexity: ['error', 10],
     'consistent-return': 'error',
     'default-case': 'error',
     'dot-location': ['error', 'property'],

--- a/test.js
+++ b/test.js
@@ -7,6 +7,7 @@ module.exports = {
     'newline-per-chained-call': 'off',
     'max-nested-callbacks': ['error', 5],
     'no-undefined': 'off',
-    'no-magic-numbers': 'off'
+    'no-magic-numbers': 'off',
+    'no-unused-expressions': 'off'
   })
 }


### PR DESCRIPTION
This PR loosens two linting rules:

**Max complexity of 3 loosened to 10**
Defaulting statements each count as 1 complexity for the eslint complexity
algorithm.

So both these statements are considered equivalent:

```
const foo = bar || 'default';

let foo
if (bar) {
  foo = bar;
} else {
  foo = 'default';
}
```

We were using complexity to prevent heavily complex if statements but
the existing `max-depth` check will suffice for this.

**Allow unused statements in tests**
Chai assertions are often unused statements, e.g.:

```
expect(foo).to.be.true;
expect(bar).to.be.undefined;
```

These are valid and useful statements in test suites and so shouldn't be
avoided.