### PR TITLE
Ignore numbers used to count

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,11 @@ module.exports = {
     'no-labels': 'error',
     'no-lone-blocks': 'error',
     'no-loop-func': 'error',
-    'no-magic-numbers': ['error', { ignoreArrayIndexes: true, enforceConst: true }],
+    'no-magic-numbers': ['error', {
+      ignoreArrayIndexes: true,
+      enforceConst: true,
+      ignore: [-1, 0, 1]
+    }],
     'no-multi-spaces': 'error',
     'no-multi-str': 'error',
     'no-new': 'error',


### PR DESCRIPTION
It's common to go:

```
let count = 0;
items.forEach(item => {
  if ([some condition]) {
    count += 1;
  }
});
```

This commit ignores `0`, `1` and `-1` so that you can count things.